### PR TITLE
Zsh vcs_info prompt replaced by gitmux

### DIFF
--- a/.gitmux.conf
+++ b/.gitmux.conf
@@ -1,0 +1,27 @@
+tmux:
+  symbols:
+    branch: '⎇ '
+    hashprefix: ':'
+    ahead: ↑·
+    behind: ↓·
+    staged: '● '
+    conflict: '✖ '
+    modified: '✚ '
+    untracked: '… '
+    stashed: '⚑ '
+    clean: ✔
+  styles:
+    clear: '#[fg=default]'
+    state: '#[fg=red,bold]'
+    branch: '#[fg=white,bold]'
+    remote: '#[fg=cyan]'
+    staged: '#[fg=green,bold]'
+    conflict: '#[fg=red,bold]'
+    modified: '#[fg=red,bold]'
+    untracked: '#[fg=magenta,bold]'
+    stashed: '#[fg=cyan,bold]'
+    clean: '#[fg=green,bold]'
+    divergence: '#[fg=default]'
+  layout: [branch, .., remote-branch, divergence, ' - ', flags]
+  options:
+    branch_max_len: 0

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -2,7 +2,7 @@
 set -g default-shell /bin/zsh
 
 # Set terminal to xterm with colors
-set -g default-terminal "xterm-256color"
+set -g default-terminal "screen-256color"
 
 # Bind prefix to C-a
 set -g prefix C-a
@@ -18,8 +18,13 @@ bind r source-file ~/.tmux.conf
 bind v split-window 
 bind h split-window -h
 
-# Vi-style copy-mode
-set-window-option -g mode-keys vi
+# Copy/Paste like in Vi
+setw -g mode-keys vi
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-selection
+bind -T copy-mode-vi V send-keys -X rectangle-toggle
+unbind -T copy-mode-vi Enter
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'xclip -se c -i'
 
 # Activity monitor
 set -g visual-activity on

--- a/.zshrc
+++ b/.zshrc
@@ -71,28 +71,33 @@ alias kx="kubectx"                                              # Alias kubectx 
 autoload -U compinit colors zcalc
 compinit -d
 colors
-# Stylize the prompt and right prompt with git info
 PROMPT='%B%F{blue}%1~%f%b %F{243}$%f '
-autoload -Uz vcs_info
-precmd_vcs_info() { vcs_info }
-precmd_functions+=( precmd_vcs_info )
-setopt prompt_subst
-RPROMPT=\$vcs_info_msg_0_
-zstyle ':vcs_info:*' enable git
-zstyle ':vcs_info:*' check-for-changes true
-zstyle ':vcs_info:*' unstagedstr '!'
-zstyle ':vcs_info:*' stagedstr '+'
-zstyle ':vcs_info:git*+set-message:*' hooks untracked
-zstyle ':vcs_info:git:*' formats '%F{red}%m%f%F{yellow}%u%f%F{green}%c%f %F{199}%b%f'
-zstyle ':vcs_info:git:*' actionformats '%F{cyan}%a%f %F{red}%m%f%F{yellow}%u%f%F{green}%c%f %F{199}%b%f'
+GIT_PROMPT=false
 
-+vi-untracked() {
-  if [[ -n "$(git ls-files --others --exclude standard)" ]]; then
-      hook_com[misc]='?'
-  else
-      hook_com[misc]=''
-  fi
-}
+# Stylize the prompt and right prompt with git info
+if [ "$GIT_PROMPT" = true ] ; then
+  autoload -Uz vcs_info
+  precmd_vcs_info() { vcs_info }
+  precmd_functions+=( precmd_vcs_info )
+  setopt prompt_subst
+  RPROMPT=\$vcs_info_msg_0_
+  zstyle ':vcs_info:*' enable git
+  zstyle ':vcs_info:*' check-for-changes true
+  zstyle ':vcs_info:*' unstagedstr '!'
+  zstyle ':vcs_info:*' stagedstr '+'
+  zstyle ':vcs_info:git*+set-message:*' hooks untracked
+  zstyle ':vcs_info:git:*' formats '%F{red}%m%f%F{yellow}%u%f%F{green}%c%f %F{199}%b%f'
+  zstyle ':vcs_info:git:*' actionformats '%F{cyan}%a%f %F{red}%m%f%F{yellow}%u%f%F{green}%c%f %F{199}%b%f'
+
+  # Add support for untracked status
+  +vi-untracked() {
+    if [[ -n "$(git ls-files --others --exclude standard)" ]]; then
+        hook_com[misc]='?'
+    else
+        hook_com[misc]=''
+    fi
+  }
+fi
 
 # Color man pages
 export LESS_TERMCAP_mb=$'\E[01;32m'

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
-CMDS=("zsh" "tmux" "kubectl" "kubectx" "vim" "curl")
+CMDS=("zsh" "tmux" "kubectl" "kubectx" "vim" "curl" "gitmux")
 
 warn() {
   echo -e "🤯 ${YELLOW}${1}${NC}"
@@ -46,12 +46,6 @@ install() {
 
   log "\t.tmux.conf"
   download ~/.tmux.conf https://raw.githubusercontent.com/amimof/dotfiles/master/.tmux.conf
-
-  info "🤖 Installing scripts"
-  mkdir -p ~/.scripts
-  
-  log "\tjonmosco/kube-tmux"
-  git clone https://github.com/jonmosco/kube-tmux.git ~/.scripts/kube-tmux/
 
   info "\n💩 Done! Restart your shell session\n"
 

--- a/settings.json
+++ b/settings.json
@@ -2,9 +2,7 @@
     "workbench.startupEditor": "newUntitledFile",
     "editor.tabSize": 2,
     "explorer.openEditors.visible": 0,
-    "workbench.activityBar.visible": false,
     "extensions.ignoreRecommendations": true,
-    "window.zoomLevel": 0,
     "html.autoClosingTags": false,
     "explorer.confirmDragAndDrop": false,
     "editor.quickSuggestions": {
@@ -13,5 +11,12 @@
         "strings": false
     },
     "editor.hover.enabled": false,
-    "breadcrumbs.enabled": false
+    "breadcrumbs.enabled": false,
+    "editor.renderControlCharacters": false,
+    "explorer.confirmDelete": false,
+    "redhat.telemetry.enabled": false,
+    "editor.renderWhitespace": "none",
+    "git.autofetch": true,
+    "workbench.activityBar.visible": false,
+    "window.zoomLevel": 1
 }


### PR DESCRIPTION
* Git status zsh prompt is optional and disabled by default. Set GIT_PROMPT=true to use it
* Uses https://github.com/arl/gitmux instead which is much faster and feature rich
* Stripped the date from status-right
* Updated installer to ignore kube-tmux